### PR TITLE
WebView has been removed from React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-f2chart",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "F2 charts for react-native",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React, { PureComponent, createRef } from "react";
-import { WebView as RNWebView, StyleSheet, Platform } from "react-native";
+import { StyleSheet, Platform } from 'react-native';
+import { WebView as RNWebView } from 'react-native-webview';
 
 const changeData = data => `chart.changeData(${JSON.stringify(data)});`;
 


### PR DESCRIPTION

webview is no longer present in the react-native library, so its import has been changed. Error:
`WebView has been removed from React Native. It can now be installed and imported from 'react-native-webview' instead of 'react-native'`
